### PR TITLE
Add gitignore for binary and user files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.pyc
+pybob.yml


### PR DESCRIPTION
The binary python files and the pybob.yml change the git status in the installation folder.

This is avoided with the gitignore file.