### PR TITLE
allows nesting in the package name and print output from execute command

### DIFF
--- a/buildconf.py
+++ b/buildconf.py
@@ -117,7 +117,9 @@ def clonePackage(cfg, package, server, gitPackage, branch):
             cmd = ["git", "clone", "-o", "autobuild", "-q", server+gitPackage, clonePath]
             if branch:
                 cmd += ["-b", branch]
-            execute.do(cmd, cfg)
+            out, err, r = execute.do(cmd, cfg)
+            print out
+            print err
             # apply patch if we have one
             patch = cfg["pyScriptDir"] + "/patches/" + package.split("/")[-1] + ".patch"
             print "check for patches",

--- a/buildconf.py
+++ b/buildconf.py
@@ -83,7 +83,8 @@ def checkBaseName(package, info):
         if "$" in info["gitPackage"] and "*" not in package:
             info["basename"] = info["gitPackage"]
             info["gitPackage"] = info["gitPackage"].replace("$PACKAGE_BASENAME",
-                                                            package.split("/")[-1])
+                                                            '-'.join((package.split("/")[1:])))                                                           
+
 
 def clonePackage(cfg, package, server, gitPackage, branch):
     clonePath = package


### PR DESCRIPTION
there is a bug with deep nesting package name, e.g. gui/osgviz/osgviz. since it took just the last split, the repository path was wrong. /gui-osgviz, but right is /gui-osgviz-osgviz
so this patch allows deeper nesting package name.