### PR TITLE
use distro module for ubuntu version check

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,15 @@
 
 # Prepare Ubuntu for pybob:
 
-       sudo apt-get install git python-yaml
+       sudo apt-get install git python-yaml python-distro
+  or (using python3)
+
+       sudo apt install git python3-yaml python3-distro
+
+You can exclude the distro module by
+
+       export QT5_UBUNTU=True
+or `False` if you have a older system which is incompatible with QT5.
 
 # Prepare Mac OS X for pybob:
 

--- a/environment.py
+++ b/environment.py
@@ -3,10 +3,22 @@
 import os
 import sys
 from platform import system
-from platform import version
 import colorconsole as c
 import subprocess
 import execute
+QT5_UBUNTU = False
+if system() == "Linux":
+    qt5_ubuntu_env_var = os.environ.get("QT5_UBUNTU")
+    if qt5_ubuntu_env_var is None:
+        try:
+            import distro
+        except ImportError:
+            raise ImportError("please install the distro package: pip install distro\n"
+                              "(or set QT5_UBUNTU to True or False prior to using pybob)")
+        QT5_UBUNTU = distro.id() == "ubuntu" and int(distro.major_version(best=True)) >= 20
+    else:
+        QT5_UBUNTU = bool(qt5_ubuntu_env_var)
+
 
 def source(sourceFile):
     newenv = {}
@@ -95,7 +107,7 @@ def setupEnv(cfg, update=False):
             elif platform == "Linux":
                 f.write('export LD_LIBRARY_PATH="'+prefix_lib+':$LD_LIBRARY_PATH"\n')
                 f.write('export CXXFLAGS="-std=c++11"\n')
-                if int(version().split("~")[1].split(".")[0]) >= 20:
+                if QT5_UBUNTU:
                     f.write('export USE_QT5=1\n')
             else:
                 f.write('export PATH="'+prefix_lib+':$PATH"\n')

--- a/osdeps.py
+++ b/osdeps.py
@@ -4,8 +4,8 @@ import os
 import colorconsole as c
 import execute
 from platform import system
-from platform import version
 import sys
+from environment import QT5_UBUNTU
 
 def pipInstall(cfg, pkg):
     """PIP installation command."""
@@ -151,7 +151,7 @@ def loadOsdeps(cfg):
             "lua51": [install, "liblua5.1-0-dev"],
             "curl": [install, "libcurl4-gnutls-dev"],
             })
-        if int(version().split("~")[1].split(".")[0]) >= 20:
+        if QT5_UBUNTU:
             cfg["osdeps"]["qt"] = [install, "qt5-default"]
             cfg["osdeps"]["qtwebkit"] = [install, "libqt5webkit5-dev"]
             cfg["osdeps"]["opencv"] = [install, "libopencv-dev"]

--- a/overrides.py
+++ b/overrides.py
@@ -1,14 +1,13 @@
 #! /usr/bin/env python
 from __future__ import print_function
 from platform import system
-from platform import version
 import sys
 import os
 import colorconsole as c
 import execute
 import yaml
 import bob_package
-from platform import system
+from environment import QT5_UBUNTU
 
 
 def uninstall_ode(cfg):
@@ -365,7 +364,7 @@ def loadOverrides(cfg):
         cfg["ignorePackages"].append("python")
         cfg["ignorePackages"].append("python-dev")
         cfg["ignorePackages"].append("python-yaml")
-    elif int(version().split("~")[1].split(".")[0]) < 20:
+    elif not QT5_UBUNTU:
         cfg["ignorePackages"].append("external/osgQt")
 
 


### PR DESCRIPTION
As discussed in [the commit comments](https://github.com/rock-simulation/pybob/commit/669d4482197a75384f8017f6fba0ed54a383d386), `platform.version` has inconsistent output (on two 18.04 kubuntu machines, I have no `~` in the output).
The distro module is dedicated for an ubuntu version check. It is an added dependency yet to be documented (`apt` or `pip`?). However one can also just  `export QT5_UBUNTU=True` or `False` to avoid installing distro.